### PR TITLE
Implement army hot-swap

### DIFF
--- a/AI/MMAI/AAI/AAI.cpp
+++ b/AI/MMAI/AAI/AAI.cpp
@@ -110,7 +110,8 @@ namespace MMAI {
             assert(!heroes.empty());
             auto h = heroes.at(0);
 
-            cb->moveHero(h, int3{2,1,0}, false);
+            // Move 1 tile to the right
+            cb->moveHero(h, h->pos + int3{1,0,0}, false);
         });
     }
 

--- a/AI/MMAI/types/battlefield.cpp
+++ b/AI/MMAI/types/battlefield.cpp
@@ -219,6 +219,13 @@ namespace MMAI {
 
     // static
     // result is a vector<UnitID>
+    // XXX: there is a bug in VCMI when high morale occurs:
+    //      - the stack acts as if it's already the next unit's turn
+    //      - as a result, QueuePos for the ACTIVE stack is non-0
+    //        while the QueuePos for the next (non-active) stack is 0
+    // XXX: possibly similar issues occur when low morale occurs
+    // As a workaround, morale is diabled (all battles are on cursed ground)
+    // Possible solution is to set some flag via BAI->battleTriggerEffect (TODO)
     Queue Battlefield::GetQueue(CBattleCallback* cb) {
         auto res = Queue{};
 

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -25,7 +25,7 @@ Here is a list of features I would like to have implemented:
 | State reporting | ✅ | VCMI must collect important aspects of the battle's state and communicate them to a separate program |
 | Map hot-swap | ❌ | Changing the map without restarting VCMI is one way change the army compositions during training, which would improve training performance |
 | Battlefield hot-swap | ❌ | Changing the battlefield terrain without changing the entire map (hence re-starting VCMI) would improve performance|
-| Army hot-swap | ❌ | Changing the army compositions without changing the entire map (hence re-starting VCMI) would improve performance |
+| Army hot-swap | ✅ | Changing the army compositions without changing the entire map (hence re-starting VCMI) would improve performance |
 
 Currently, I am mostly focused on the training process itself (as part of
 [vcmi-gym](https://github.com/smanolloff/vcmi-gym)), but the fact there are

--- a/lib/gameState/CGameState.h
+++ b/lib/gameState/CGameState.h
@@ -81,6 +81,10 @@ class DLL_LINKAGE CGameState : public CNonConstInfoCallback
 	friend class CGameStateCampaign;
 
 public:
+	// SIMO gym battles with random heroes
+	std::vector<const CGHeroInstance*> allheroes;
+	int herocounter = 0;
+
 	//we have here all heroes available on this map that are not hired
 	std::unique_ptr<TavernHeroesPool> heroesPool;
 

--- a/myclient/main-shared.cpp
+++ b/myclient/main-shared.cpp
@@ -92,7 +92,7 @@ Args parse_args(int argc, char * argv[])
 {
     // std::vector<std::string> ais = {"StupidAI", "BattleAI", "MMAI", "MMAI_MODEL"};
     auto omap = std::map<std::string, std::string> {
-        {"map", "ai/P1.vmap"},
+        {"map", "gym/A1.vmap"},
         {"loglevel-global", "error"},
         {"loglevel-ai", "debug"},
         {"attacker-ai", AI_MMAI_USER},
@@ -197,6 +197,8 @@ Args parse_args(int argc, char * argv[])
             act = interactive
                 ? promptAction(lastmasks.at(side))
                 : (prerecorded ? recordedAction(recordings) : randomValidAction(lastmasks.at(side)));
+
+            renders.at(side) = false;
         } else if (r->ended) {
             if (side == benchside) {
                 resets++;
@@ -222,7 +224,7 @@ Args parse_args(int argc, char * argv[])
             if (!benchmark) LOG("user-callback battle ended => sending ACTION_RESET");
             act = MMAI::Export::ACTION_RESET;
         } else if (!benchmark && !renders.at(side)) {
-            renders[side] = true;
+            renders.at(side) = true;
             // store mask of this result for the next action
             lastmasks.at(side) = r->actmask;
             act = MMAI::Export::ACTION_RENDER_ANSI;


### PR DESCRIPTION
A list of armies ("army pool") is created from all heroes the map (i.e. max 64 armies).

A (different) pair of armies is used on each battle replays. After each full pass of the list, the entries are shuffled.